### PR TITLE
Add width: 100% to SVG elements as a workaround for Safari

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -58,6 +58,7 @@ export default function Home() {
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
+                width="100%"
                 viewBox="0 0 24 24"
                 strokeWidth="1.5"
                 stroke="currentColor"
@@ -72,6 +73,7 @@ export default function Home() {
               <svg
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
+                width="100%"
                 viewBox="0 0 24 24"
                 strokeWidth={1.5}
                 stroke="currentColor"


### PR DESCRIPTION
Implement a workaround to address a potential bug in Safari by setting the width of SVG elements to 100%.