### PR TITLE
Change timer color to red when < 30 seconds remaining

### DIFF
--- a/src/components/timer.tsx
+++ b/src/components/timer.tsx
@@ -8,13 +8,17 @@ export default function Timer({ time }: { time: number }) {
     <div className="w-full flex flex-row justify-center">
       <div className="grid grid-flow-col gap-5 text-center auto-cols-max">
         <div className="flex flex-col">
-          <span className="countdown font-mono text-6xl md:text-9xl">
+          <span
+            className={`countdown font-mono text-6xl md:text-9xl ${time <= 30 ? "text-error" : ""}`}
+          >
             <span style={{ "--value": `${minutes}` } as CSSProperties}></span>
           </span>
           min
         </div>
         <div className="flex flex-col">
-          <span className="countdown font-mono text-6xl md:text-9xl">
+          <span
+            className={`countdown font-mono text-6xl md:text-9xl ${time <= 30 ? "text-error" : ""}`}
+          >
             <span
               style={{ "--value": `${remainingSeconds}` } as CSSProperties}
             ></span>


### PR DESCRIPTION
⏲️ 
This pull request includes changes to the `Timer` component in the `src/components/timer.tsx` file to enhance the user interface by adding a visual indication when the timer is running low.

UI Improvements:

* [`src/components/timer.tsx`](diffhunk://#diff-2beab74649ec1e95ef642c77ae474d0304b5b51d7ad4346d5698e113f44e7f73L11-R21): Modified the `Timer` component to add a `text-error` class when the `time` is less than or equal to 30 seconds. This change helps to visually alert users when the timer is running low.