### PR TITLE
Disable ESLint warning for useEffect dependencies

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -76,6 +76,7 @@ export default function Home() {
   useEffect(() => {
     setTime(initialTime);
     setSb(calculateSb(level, initialSb));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [level]);
 
   return (


### PR DESCRIPTION
Suppress the ESLint warning related to exhaustive dependencies in the useEffect hook.