### PR TITLE
Make the blind schedule editable and persist everything

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,10 +18,14 @@ Before calling a change done, run `lint`, `typecheck`, and `build`.
 ## Layout
 
 - `src/app/page.tsx` — the whole app. Client component holding all state
-  (`time`, `level`, `paused`) plus the `calculateSb` blind schedule. `sb` is
-  derived from `level` during render, not stored. Level count (`maxLevel`) and
-  level length (`initialTime`) are constants here.
+  (`time`, `level`, `paused`, `settings`). `sb`, `maxLevel`, and the level
+  length are all derived from `settings` during render, not stored.
+- `src/lib/settings.ts` — the `Settings` type, the default blind schedule,
+  and the localStorage load/save (with validation). The in-progress game is
+  persisted separately under `poker-timer:game` by `page.tsx`.
 - `src/components/*` — presentational only, props in, no state of their own.
+  The one exception is `settings-dialog.tsx`, which keeps draft state while
+  editing; the page remounts it (via `key`) when saved settings change.
 - `src/app/globals.css` — the Tailwind 4 CSS-first config (`@theme`: colors,
   fonts, the `invert-flicker` animation) plus the hand-written widget classes
   (`.btn*`, `.digit` rolling countdown, `.steps`/`.step` level indicator).
@@ -36,10 +40,10 @@ Before calling a change done, run `lint`, `typecheck`, and `build`.
 - **A green build does not mean the UI works.** For any styling change, check
   the real page: the countdown digits should roll (`.digit` strips), and
   `.btn-primary` should have a non-transparent background.
-- **Level count is hardcoded in three places** — `maxLevel` in `page.tsx`,
-  `maxLevel` in `prev-next-button.tsx`, and the nine hand-written `<li>`
-  elements in `blind-level.tsx`. Changing the schedule means touching all three.
-- **`calculateSb` throws** on any level outside 1–9 rather than clamping.
+- **localStorage is only touched after mount.** The server render always uses
+  the defaults; settings and the saved game are restored in a mount effect to
+  avoid hydration mismatches. Saved data is validated on load — anything out
+  of range falls back to a fresh game.
 - **`postcss` and `sharp` are forced forward by npm `overrides`.** `next` pins
   `postcss` to 8.4.31 and caps `sharp` at `^0.34.5`, both with open advisories;
   the overrides in `package.json` are what keep `npm audit` at zero. The

--- a/README.md
+++ b/README.md
@@ -35,25 +35,26 @@ Then open <http://localhost:3000>.
 ## How it works
 
 Everything lives in a single client component, [`src/app/page.tsx`](src/app/page.tsx),
-which owns all the state — `time`, `sb`, `level`, `paused`:
+which owns all the state — `time`, `level`, `paused`, `settings`:
 
-- **9 blind levels**, 10 minutes each. Both are constants at the top of
-  `page.tsx` (`initialTime`, `initialSb`) — change them there.
-- **Blind schedule** is the `calculateSb` function at the bottom of `page.tsx`.
-  It multiplies the initial small blind by `1, 2, 3, 5, 10, 15, 20, 40, 80`.
-  BB is always 2×SB, computed in [`sb-bb.tsx`](src/components/sb-bb.tsx).
+- **9 blind levels by default**, 10 minutes each, small blinds
+  `100, 200, 300, 500, 1000, 1500, 2000, 4000, 8000`. BB is always 2×SB.
+  The defaults live in [`src/lib/settings.ts`](src/lib/settings.ts).
+- **Everything is editable** in the settings dialog (gear icon, a native
+  `<dialog>`): minutes per level, and the small blind for each level —
+  add or remove levels freely. Saved settings persist in `localStorage`.
+- **The game survives a reload.** The current level and remaining time are
+  saved as they change and restored (paused) on the next visit.
 - **Under 30 seconds** the background turns red (`bg-error`).
 - **At zero** it plays a triple beep generated with the Web Audio API (no
   audio asset), vibrates on devices that support it, flashes the screen with
   the custom `invert-flicker` animation from
   [`globals.css`](src/app/globals.css), and advances to the next level.
-  After level 9 it pauses instead.
+  After the last level it pauses instead.
 - **The clock doesn't drift.** While running, the remaining time is recomputed
   every 250 ms from a deadline timestamp, so it stays correct even when the
   browser throttles timers in a background tab.
 - **Prev/next buttons** jump levels manually and reset the clock either way.
-
-State is in-memory only — a page refresh restarts at level 1.
 
 ## Stack
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -100,6 +100,20 @@
     pointer-events: none;
   }
 
+  .input {
+    height: 2.5rem;
+    padding-inline: 0.75rem;
+    border-radius: 0.5rem;
+    border: 1px solid var(--muted);
+    background: transparent;
+    color: inherit;
+  }
+
+  .input:focus-visible {
+    outline: 2px solid var(--primary);
+    outline-offset: 1px;
+  }
+
   /* Rolling countdown digit: a 0-9 strip, one digit tall, shifted per value */
   .digit {
     display: inline-block;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,22 +6,30 @@ import Navbar from "@/components/navbar";
 import PlayPauseButton from "@/components/play-pause-button";
 import PrevNextButton from "@/components/prev-next-button";
 import SbBb from "@/components/sb-bb";
+import SettingsDialog from "@/components/settings-dialog";
 import Timer from "@/components/timer";
-import { useEffect, useRef, useState } from "react";
+import {
+  defaultSettings,
+  loadSettings,
+  saveSettings,
+  Settings,
+} from "@/lib/settings";
+import { useCallback, useEffect, useRef, useState } from "react";
 
-const initialTime = 10 * 60; // 10 minutes
-const initialSb = 100;
-const maxLevel = 9;
+const GAME_KEY = "poker-timer:game";
 
 export default function Home() {
-  const [time, setTime] = useState(initialTime);
+  const [settings, setSettings] = useState(defaultSettings);
+  const [time, setTime] = useState(defaultSettings.levelMinutes * 60);
   const [level, setLevel] = useState(1);
   const [paused, setPaused] = useState(true);
   const [flashing, setFlashing] = useState(false);
 
+  const levelSeconds = settings.levelMinutes * 60;
+  const maxLevel = settings.smallBlinds.length;
   // The blinds are fully determined by the level, so derive them during render
   // instead of keeping a second copy in state
-  const sb = calculateSb(level, initialSb);
+  const sb = settings.smallBlinds[level - 1];
 
   // While running, the source of truth for the remaining time is a deadline
   // timestamp, not a decrementing counter: each tick recomputes the remaining
@@ -32,6 +40,64 @@ export default function Home() {
   // Lazily created on the first play press (a user gesture, which is what
   // browser autoplay policies require to unlock audio)
   const audioCtxRef = useRef<AudioContext | null>(null);
+
+  const settingsDialogRef = useRef<HTMLDialogElement>(null);
+
+  // Blocks the game-state persist effect from clobbering the saved game with
+  // defaults before the restore below has run
+  const restoredRef = useRef(false);
+
+  // Restore settings and any in-progress game after mount; the server render
+  // must use the defaults, so localStorage can only be read here. The one-off
+  // cascading render this causes is exactly the intended hydration step.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    const stored = loadSettings();
+    if (stored) {
+      setSettings(stored);
+    }
+    const active = stored ?? defaultSettings;
+    const seconds = active.levelMinutes * 60;
+
+    const game = loadGame(active);
+    if (game) {
+      setLevel(game.level);
+      setTime(game.remaining);
+    } else {
+      setTime(seconds);
+    }
+    restoredRef.current = true;
+  }, []);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  // Persist the game so a reload or accidental tab close resumes where the
+  // game left off (always paused, never mid-countdown)
+  useEffect(() => {
+    if (!restoredRef.current) {
+      return;
+    }
+    localStorage.setItem(GAME_KEY, JSON.stringify({ level, remaining: time }));
+  }, [level, time]);
+
+  // Flash the screen to tell inaudible users that the time is up, using the
+  // invert-flicker animation defined in globals.css
+  const flash = useCallback(() => {
+    setFlashing(true);
+    setTimeout(() => setFlashing(false), 1000);
+  }, []);
+
+  const goToLevel = useCallback(
+    (nextLevel: number) => {
+      setLevel(nextLevel);
+      setTime(levelSeconds);
+      // A non-null deadline means the clock is running; checking the ref (not
+      // `paused`) keeps this correct even from a stale closure
+      if (endAtRef.current !== null) {
+        endAtRef.current = Date.now() + levelSeconds * 1000;
+      }
+    },
+    [levelSeconds],
+  );
 
   useEffect(() => {
     if (paused) {
@@ -64,17 +130,7 @@ export default function Home() {
     }, 250);
 
     return () => clearInterval(timer);
-  }, [paused, level]);
-
-  function goToLevel(nextLevel: number) {
-    setLevel(nextLevel);
-    setTime(initialTime);
-    // A non-null deadline means the clock is running; checking the ref (not
-    // `paused`) keeps this correct even from a stale closure
-    if (endAtRef.current !== null) {
-      endAtRef.current = Date.now() + initialTime * 1000;
-    }
-  }
+  }, [paused, level, maxLevel, goToLevel, flash]);
 
   function togglePaused() {
     if (paused) {
@@ -95,11 +151,14 @@ export default function Home() {
     setPaused(true);
   }
 
-  // Flash the screen to tell inaudible users that the time is up, using the
-  // invert-flicker animation defined in globals.css
-  function flash() {
-    setFlashing(true);
-    setTimeout(() => setFlashing(false), 1000);
+  function applySettings(next: Settings) {
+    saveSettings(next);
+    setSettings(next);
+    // New schedule, new game
+    endAtRef.current = null;
+    setPaused(true);
+    setLevel(1);
+    setTime(next.levelMinutes * 60);
   }
 
   return (
@@ -110,33 +169,78 @@ export default function Home() {
         time < 30 ? "bg-error" : ""
       } ${flashing ? "animate-invert-flicker" : ""}`}
     >
-      <Navbar />
+      <Navbar
+        onOpenSettings={() => settingsDialogRef.current?.showModal()}
+      />
       <main className="flex flex-col gap-8 row-start-2 items-center sm:items-start">
         <div className="w-16"></div>
         <Timer time={time} />
         <div className="self-center flex flex-row gap-8">
           <PrevNextButton
             currentLevel={level}
+            maxLevel={maxLevel}
             onLevelChange={goToLevel}
             type={"prev"}
           />
           <PlayPauseButton onToggle={togglePaused} paused={paused} />
           <PrevNextButton
             currentLevel={level}
+            maxLevel={maxLevel}
             onLevelChange={goToLevel}
             type={"next"}
           />
         </div>
         <SbBb sb={sb} />
-        <BlindLevel level={level} />
+        <BlindLevel level={level} maxLevel={maxLevel} />
       </main>
       <Footer />
+      <SettingsDialog
+        // Remount on settings change so the dialog's draft state always
+        // starts from the currently saved settings
+        key={JSON.stringify(settings)}
+        ref={settingsDialogRef}
+        settings={settings}
+        onSave={applySettings}
+      />
     </div>
   );
 }
 
 function remainingSeconds(endAt: number) {
   return Math.max(0, Math.ceil((endAt - Date.now()) / 1000));
+}
+
+// Reads the saved game and validates it against the active settings; anything
+// out of range (e.g. the schedule shrank) starts a fresh game instead
+function loadGame(settings: Settings): { level: number; remaining: number } | null {
+  try {
+    const raw = localStorage.getItem(GAME_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) {
+      return null;
+    }
+
+    const { level, remaining } = parsed as Record<string, unknown>;
+    const seconds = settings.levelMinutes * 60;
+    if (
+      !Number.isInteger(level) ||
+      (level as number) < 1 ||
+      (level as number) > settings.smallBlinds.length ||
+      !Number.isInteger(remaining) ||
+      (remaining as number) < 0 ||
+      (remaining as number) > seconds
+    ) {
+      return null;
+    }
+
+    return { level: level as number, remaining: remaining as number };
+  } catch {
+    return null;
+  }
 }
 
 // A short triple beep generated with the Web Audio API — no audio asset needed
@@ -161,30 +265,5 @@ function beep(ctx: AudioContext | null) {
     gain.connect(ctx.destination);
     oscillator.start(t);
     oscillator.stop(t + 0.22);
-  }
-}
-
-function calculateSb(level: number, initialSb: number) {
-  switch (level) {
-    case 1:
-      return initialSb;
-    case 2:
-      return initialSb * 2;
-    case 3:
-      return initialSb * 3;
-    case 4:
-      return initialSb * 5;
-    case 5:
-      return initialSb * 10;
-    case 6:
-      return initialSb * 15;
-    case 7:
-      return initialSb * 20;
-    case 8:
-      return initialSb * 40;
-    case 9:
-      return initialSb * 80;
-    default:
-      throw new Error("Level not found");
   }
 }

--- a/src/components/blind-level.tsx
+++ b/src/components/blind-level.tsx
@@ -1,15 +1,14 @@
-export default function BlindLevel({ level }: { level: number }) {
+interface Props {
+  level: number;
+  maxLevel: number;
+}
+
+export default function BlindLevel({ level, maxLevel }: Props) {
   return (
-    <ul className="steps hidden lg:inline-grid ">
-      <li className={level >= 1 ? "step step-primary" : "step"}></li>
-      <li className={level >= 2 ? "step step-primary" : "step"}></li>
-      <li className={level >= 3 ? "step step-primary" : "step"}></li>
-      <li className={level >= 4 ? "step step-primary" : "step"}></li>
-      <li className={level >= 5 ? "step step-primary" : "step"}></li>
-      <li className={level >= 6 ? "step step-primary" : "step"}></li>
-      <li className={level >= 7 ? "step step-primary" : "step"}></li>
-      <li className={level >= 8 ? "step step-primary" : "step"}></li>
-      <li className={level >= 9 ? "step step-primary" : "step"}></li>
+    <ul className="steps hidden lg:inline-grid">
+      {Array.from({ length: maxLevel }, (_, i) => (
+        <li key={i} className={level >= i + 1 ? "step step-primary" : "step"} />
+      ))}
     </ul>
   );
 }

--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -1,7 +1,36 @@
-export default function Navbar() {
+interface Props {
+  onOpenSettings: () => void;
+}
+
+export default function Navbar({ onOpenSettings }: Props) {
   return (
-    <div className="absolute top-0 w-full flex flex-row items-center min-h-16 p-2 justify-center md:justify-start pl-8">
+    <div className="absolute top-0 w-full flex flex-row items-center min-h-16 p-2 justify-center md:justify-start px-8">
       <h1 className="text-2xl font-mono font-bold">Poker Timer</h1>
+      <button
+        className="btn btn-ghost btn-square absolute right-4"
+        aria-label="Settings"
+        onClick={onOpenSettings}
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={1.5}
+          stroke="currentColor"
+          className="size-6"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M9.594 3.94c.09-.542.56-.94 1.11-.94h2.593c.55 0 1.02.398 1.11.94l.213 1.281c.063.374.313.686.645.87.074.04.147.083.22.127.325.196.72.257 1.075.124l1.217-.456a1.125 1.125 0 0 1 1.37.49l1.296 2.247a1.125 1.125 0 0 1-.26 1.431l-1.003.827c-.293.241-.438.613-.43.992a7.723 7.723 0 0 1 0 .255c-.008.378.137.75.43.991l1.004.827c.424.35.534.955.26 1.43l-1.298 2.247a1.125 1.125 0 0 1-1.369.491l-1.217-.456c-.355-.133-.75-.072-1.076.124a6.47 6.47 0 0 1-.22.128c-.331.183-.581.495-.644.869l-.213 1.281c-.09.543-.56.94-1.11.94h-2.594c-.55 0-1.019-.398-1.111-.94l-.213-1.281c-.062-.374-.312-.686-.644-.87a6.52 6.52 0 0 1-.22-.127c-.325-.196-.72-.257-1.076-.124l-1.217.456a1.125 1.125 0 0 1-1.369-.49l-1.297-2.247a1.125 1.125 0 0 1 .26-1.431l1.004-.827c.292-.24.437-.613.43-.991a6.932 6.932 0 0 1 0-.255c.007-.38-.138-.751-.43-.992l-1.004-.827a1.125 1.125 0 0 1-.26-1.43l1.297-2.247a1.125 1.125 0 0 1 1.37-.491l1.216.456c.356.133.751.072 1.076-.124.072-.044.146-.086.22-.128.332-.183.582-.495.644-.869l.214-1.28Z"
+          />
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M15 12a3 3 0 1 1-6 0 3 3 0 0 1 6 0Z"
+          />
+        </svg>
+      </button>
     </div>
   );
 }

--- a/src/components/prev-next-button.tsx
+++ b/src/components/prev-next-button.tsx
@@ -1,20 +1,21 @@
 interface Props {
   type: "prev" | "next";
   currentLevel: number;
+  maxLevel: number;
   onLevelChange: (level: number) => void;
 }
 
 export default function PrevNextButton(props: Props) {
-  const { type, currentLevel, onLevelChange } = props;
-  const minLvel = 1;
-  const maxLevel = 9;
+  const { type, currentLevel, maxLevel, onLevelChange } = props;
+  const minLevel = 1;
   const disabled =
-    (currentLevel === minLvel && type === "prev") ||
+    (currentLevel === minLevel && type === "prev") ||
     (currentLevel === maxLevel && type === "next");
 
   return (
     <button
       className={`btn btn-ghost ${disabled ? "btn-disabled" : ""}`}
+      aria-label={type === "prev" ? "Previous level" : "Next level"}
       onClick={function () {
         if (disabled) {
           return;

--- a/src/components/settings-dialog.tsx
+++ b/src/components/settings-dialog.tsx
@@ -1,0 +1,128 @@
+import { Ref, useState } from "react";
+import { defaultSettings, Settings } from "@/lib/settings";
+
+interface Props {
+  ref: Ref<HTMLDialogElement>;
+  settings: Settings;
+  onSave: (settings: Settings) => void;
+}
+
+// The page remounts this component (via `key`) whenever the saved settings
+// change, so the draft state below always starts from the current settings
+export default function SettingsDialog({ ref, settings, onSave }: Props) {
+  const [minutes, setMinutes] = useState(settings.levelMinutes);
+  const [blinds, setBlinds] = useState(settings.smallBlinds);
+
+  const valid =
+    Number.isInteger(minutes) &&
+    minutes >= 1 &&
+    blinds.length >= 1 &&
+    blinds.every((sb) => Number.isInteger(sb) && sb >= 1);
+
+  function setBlind(index: number, value: number) {
+    setBlinds(blinds.map((sb, i) => (i === index ? value : sb)));
+  }
+
+  function reset() {
+    setMinutes(defaultSettings.levelMinutes);
+    setBlinds(defaultSettings.smallBlinds);
+  }
+
+  return (
+    <dialog
+      ref={ref}
+      className="m-auto w-full max-w-md rounded-2xl bg-background text-foreground p-6 shadow-lg backdrop:bg-black/60"
+      // Closing without saving discards the draft
+      onClose={(e) => {
+        setMinutes(settings.levelMinutes);
+        setBlinds(settings.smallBlinds);
+        e.currentTarget.scrollTop = 0;
+      }}
+    >
+      <h2 className="text-lg font-bold mb-4">Settings</h2>
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (!valid) {
+            return;
+          }
+          onSave({ levelMinutes: minutes, smallBlinds: blinds });
+          e.currentTarget.closest("dialog")?.close();
+        }}
+      >
+        <label className="flex items-center justify-between gap-4 mb-6">
+          <span>Minutes per level</span>
+          <input
+            type="number"
+            min={1}
+            value={Number.isNaN(minutes) ? "" : minutes}
+            onChange={(e) => setMinutes(e.target.valueAsNumber)}
+            className="input w-24"
+          />
+        </label>
+
+        <div className="flex flex-col gap-2 mb-4">
+          {blinds.map((sb, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <span className="w-16 shrink-0 text-sm opacity-60">
+                Level {i + 1}
+              </span>
+              <input
+                type="number"
+                min={1}
+                aria-label={`Small blind for level ${i + 1}`}
+                value={Number.isNaN(sb) ? "" : sb}
+                onChange={(e) => setBlind(i, e.target.valueAsNumber)}
+                className="input flex-1"
+              />
+              <span className="w-20 shrink-0 text-sm opacity-60 text-right tabular-nums">
+                BB {Number.isInteger(sb) ? (sb * 2).toLocaleString() : "—"}
+              </span>
+              <button
+                type="button"
+                aria-label={`Remove level ${i + 1}`}
+                disabled={blinds.length === 1}
+                onClick={() => setBlinds(blinds.filter((_, j) => j !== i))}
+                className="btn btn-ghost btn-square disabled:opacity-30"
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={() =>
+            setBlinds([...blinds, (blinds[blinds.length - 1] || 100) * 2])
+          }
+          className="btn btn-ghost w-full mb-6"
+        >
+          + Add level
+        </button>
+
+        <div className="flex justify-between gap-2">
+          <button type="button" onClick={reset} className="btn btn-ghost">
+            Reset to defaults
+          </button>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={(e) => e.currentTarget.closest("dialog")?.close()}
+              className="btn"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!valid}
+              className="btn btn-primary disabled:opacity-30"
+            >
+              Save
+            </button>
+          </div>
+        </div>
+      </form>
+    </dialog>
+  );
+}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -1,0 +1,50 @@
+export type Settings = {
+  levelMinutes: number;
+  smallBlinds: number[]; // one entry per level; BB is always 2×SB
+};
+
+// The classic schedule this app has always shipped with:
+// 100 × [1, 2, 3, 5, 10, 15, 20, 40, 80]
+export const defaultSettings: Settings = {
+  levelMinutes: 10,
+  smallBlinds: [100, 200, 300, 500, 1000, 1500, 2000, 4000, 8000],
+};
+
+const SETTINGS_KEY = "poker-timer:settings";
+
+export function loadSettings(): Settings | null {
+  try {
+    const raw = localStorage.getItem(SETTINGS_KEY);
+    if (!raw) {
+      return null;
+    }
+
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) {
+      return null;
+    }
+
+    const { levelMinutes, smallBlinds } = parsed as Record<string, unknown>;
+    if (!Number.isInteger(levelMinutes) || (levelMinutes as number) < 1) {
+      return null;
+    }
+    if (
+      !Array.isArray(smallBlinds) ||
+      smallBlinds.length === 0 ||
+      !smallBlinds.every((sb) => Number.isInteger(sb) && sb >= 1)
+    ) {
+      return null;
+    }
+
+    return {
+      levelMinutes: levelMinutes as number,
+      smallBlinds: smallBlinds as number[],
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function saveSettings(settings: Settings) {
+  localStorage.setItem(SETTINGS_KEY, JSON.stringify(settings));
+}


### PR DESCRIPTION
**Stack 3/4** — base: `stack/timer-core` (#119)

Until now, changing the schedule meant editing the source in three places, and a page refresh threw the game away mid-session.

- The schedule is data: `Settings { levelMinutes, smallBlinds[] }` in `src/lib/settings.ts`, defaulting to the classic `100 × [1,2,3,5,10,15,20,40,80]`. `calculateSb` (which **threw** outside levels 1–9) and the three hardcoded copies of the level count are gone — the level indicator and the prev/next bounds derive from the schedule length
- New settings dialog — a native `<dialog>` + `showModal()`, opened from a gear button in the navbar: minutes per level, per-level small blinds with add/remove rows, and reset-to-defaults. Saved to `localStorage`, validated on load
- The in-progress game (`{ level, remaining }`) persists as it changes and is restored **paused** after a reload or an accidental tab close. The server render sticks to the defaults and restore happens in a mount effect, so hydration stays consistent

### Verification

`lint`, `typecheck`, `build` pass. In the browser: editing minutes, a small blind, and removing a level updated the timer, blinds, and step count immediately and survived a reload; an in-progress game at level 2 restored paused with the exact remaining time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)